### PR TITLE
Add PAB configurations for unrestricted owner access

### DIFF
--- a/pab/binding.json
+++ b/pab/binding.json
@@ -1,0 +1,12 @@
+{
+  "target": {
+    "principalSet": "//cloudresourcemanager.googleapis.com/projects/api-for-warp-drive"
+  },
+  "policyKind": "PRINCIPAL_ACCESS_BOUNDARY",
+  "policy": "organizations/0123456789012/locations/global/principalAccessBoundaryPolicies/unrestricted-access",
+  "condition": {
+    "title": "Owner access",
+    "description": "Apply only to project owner",
+    "expression": "principal.subject == 'pr@coaching2100.com'"
+  }
+}

--- a/pab/policy.json
+++ b/pab/policy.json
@@ -1,0 +1,14 @@
+{
+  "name": "organizations/0123456789012/locations/global/principalAccessBoundaryPolicies/unrestricted-access",
+  "displayName": "Unrestricted Access Policy",
+  "details": {
+    "rules": [
+      {
+        "description": "Allow access to all resources",
+        "resources": ["*"],
+        "effect": "ALLOW"
+      }
+    ],
+    "enforcementVersion": "1"
+  }
+}


### PR DESCRIPTION
Adds PAB policy and binding to:
- Allow unrestricted access for pr@coaching2100.com
- Configure PAB policy for api-for-warp-drive project