### PR TITLE
Add SSL configuration for 2100.cool domains

### DIFF
--- a/ssl/config.yaml
+++ b/ssl/config.yaml
@@ -1,0 +1,15 @@
+# SSL Configuration for 2100.cool domains
+
+domains:
+  production:
+    domain: 2100.cool
+    certificate_name: 2100-cool-cert
+    proxy_name: prod-https-proxy
+  staging:
+    domain: staging.2100.cool
+    certificate_name: staging-2100-cool-cert
+    proxy_name: staging-https-proxy
+
+project:
+  id: api-for-warp-drive
+  region: us-central1

--- a/ssl/setup.sh
+++ b/ssl/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# SSL Configuration Script
+PROJECT_ID="api-for-warp-drive"
+
+# Configure SSL certificates
+echo "Setting up SSL certificates..."
+
+# Production certificate
+gcloud compute ssl-certificates create 2100-cool-cert \
+    --domains=2100.cool \
+    --global \
+    --project=$PROJECT_ID
+
+# Staging certificate
+gcloud compute ssl-certificates create staging-2100-cool-cert \
+    --domains=staging.2100.cool \
+    --global \
+    --project=$PROJECT_ID
+
+# Update load balancer configurations
+echo "Updating load balancer configurations..."
+
+# Production proxy
+gcloud compute target-https-proxies update prod-https-proxy \
+    --ssl-certificates=2100-cool-cert \
+    --global \
+    --project=$PROJECT_ID
+
+# Staging proxy
+gcloud compute target-https-proxies update staging-https-proxy \
+    --ssl-certificates=staging-2100-cool-cert \
+    --global \
+    --project=$PROJECT_ID
+
+echo "SSL configuration complete!"

--- a/ssl/verify.sh
+++ b/ssl/verify.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# SSL Verification Script
+PROJECT_ID="api-for-warp-drive"
+
+# Check certificate status
+echo "Checking SSL certificates..."
+gcloud compute ssl-certificates list \
+    --project=$PROJECT_ID \
+    --filter="name~2100-cool"
+
+# Check proxy configurations
+echo "\nChecking HTTPS proxy configurations..."
+gcloud compute target-https-proxies list \
+    --project=$PROJECT_ID
+
+# Verify domains
+echo "\nVerifying domain configurations..."
+for domain in "2100.cool" "staging.2100.cool"; do
+    echo "\nChecking $domain..."
+    curl -I https://$domain
+done


### PR DESCRIPTION
This PR adds SSL configuration files for both staging.2100.cool and 2100.cool domains.

Changes include:
1. SSL configuration YAML file
2. Setup script for creating and configuring certificates
3. Verification script for monitoring certificate status

To deploy:
1. Review the configuration in `ssl/config.yaml`
2. Run `./ssl/setup.sh` to create certificates
3. Run `./ssl/verify.sh` to confirm configuration

Please review and ensure the domain configurations match your requirements.